### PR TITLE
Add cargo-deb packaging configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "peach-probe"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "const_format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,26 @@
 [package]
 name = "peach-probe"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
+description = "Diagnostic tool for probing PeachCloud microservices to evaluate their state and ensure correct API responses"
+homepage = "https://opencollective.com/peachcloud"
+repository = "https://github.com/peachcloud/peach-probe"
+readme = "README.md"
+license = "AGPL-3.0-only"
+publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.deb]
+depends = "$auto"
+extended-description = """\
+peach-probe is a diagnostic tool for probing PeachCloud microservices to evaluate their state" \
+and ensure correct API responses" \
+"""
+maintainer-scripts="debian"
+assets = [
+    ["target/release/peach-probe", "usr/bin/", "755"],
+    ["README.md", "usr/share/doc/peach-probe/README", "644"],
+]
 
 [dependencies]
 structopt = "0.3.13"
@@ -19,7 +35,6 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 peach-lib = { git = "https://github.com/peachcloud/peach-lib", branch = "main" }
-#peach-lib = { path = "../peach-lib" }
 clap = "2.33.3"
 const_format = "0.2.10"
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ extended-description = """\
 peach-probe is a diagnostic tool for probing PeachCloud microservices to evaluate their state" \
 and ensure correct API responses" \
 """
-maintainer-scripts="debian"
 assets = [
     ["target/release/peach-probe", "usr/bin/", "755"],
     ["README.md", "usr/share/doc/peach-probe/README", "644"],

--- a/README.md
+++ b/README.md
@@ -1,42 +1,50 @@
 # peach-probe
 
-![Generic badge](https://img.shields.io/badge/version-0.1.0-<COLOR>.svg)
+![Generic badge](https://img.shields.io/badge/version-0.1.1-<COLOR>.svg)
 
 Probe PeachCloud microservices to evaluate their state and ensure correct API responses.
 
-`peach-probe` is a CLI tool for contract testing of the public API's exposed by PeachCloud microservices. It is composed of JSON-RPC clients which make calls to the methods of their respective servers and report back on the results.
+`peach-probe` is a CLI tool for contract testing of the public API's exposed by PeachCloud microservices. 
+It is composed of JSON-RPC clients which make calls to the methods of their respective servers and 
+generates a report with the results.
+
+`peach-probe` also makes use of `systemctl status` commands to test the status of all PeachCloud microservices.
 
 This utility is intended to provide a rapid means of testing a deployed PeachCloud system and allow informed trouble-shooting in the case of errors.
 
-## Design Specification
+## Installation
 
-Functionality:
+After adding releases.peachcloud.org to /etc/sources.list, as described [here](https://github.com/peachcloud/peach-vps/blob/main/README.md),
+peach-probe can be installed by running:
+`sudo apt-get install peach-probe`
 
- - Probe all microservices
- - Probe a single microservice
+## Usage
 
-Configurability:
+```bash
+USAGE:
+    peach-probe [FLAGS] [services]...
 
- - Microservice address and port
-   - Defaults defined in code
-   - `port` flag allows the server port of each service to be defined manually
-   - Optional: define parameters in a toml file
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+    -v, --verbose    prints successful endpoint calls in addition to errors
 
-Reporting:
+ARGS:
+    <services>...   [possible values: peach_oled, peach_Network, peach_stats, peach_menu, peach_web,
+                     peach_Buttons, peach_monitor]
+```
 
- - Granular reporting based on flags and options
-   - Simple pass / fail
-     - Could be similar to systemd: active, degraded, inactive
-   - Details on unexpected responses (degraded state)
-     - Example: permission denied reponse for `get_status` call for `wlan0` to `peach-network` microservice
-     - Possible fixes for errors
+If no service arguments are provided, peach-probe will query all services.
 
-## Suggested Implementation
+## Custom Port Numbers
 
- - Use [structopt](https://crates.io/crates/structopt) for CLI definitions and argument parsing
- - Create a separate module for each microservice's JSON-RPC client (ie. `stats.rs`, `oled.rs` etc.)
-   - Use [jsonrpc-client-http](https://crates.io/crates/jsonrpc-client-http)
-   - Examples in [peach-web](https://github.com/peachcloud/peach-web) (eg. `src/stats_client.rs`)
+If peach-microservices are running on ports other than the default ports, 
+this can be specified using environmental variables as documented [here](https://github.com/peachcloud/peach-lib/blob/main/README.md).
+
+## Todo
+
+ - On detecting certain errors, suggest possible fixes
+ - Finish querying of all peach-network endpoints
 
 ## Licensing
 

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -218,7 +218,6 @@ impl PeachProbe {
                                 if err.code.code() == expected_error_code {
                                     if self.verbose {
                                         println!("++ {} endpoint is online", endpoint_name);
-//                                        println!("++ returned error: {:#?}", err);
                                     }
                                     result.successes.push(endpoint_name.to_string());
                                 } else {

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -250,7 +250,6 @@ impl PeachProbe {
 
     /// probes all endpoints on the peach-stats microservice
     pub fn peach_stats(&mut self, mut result: ProbeResult) -> ProbeResult {
-
         // probe endpoints
         self.probe_peach_endpoint(
             stats_client::cpu_stats_percent(),
@@ -269,7 +268,6 @@ impl PeachProbe {
 
     /// probes all endpoints on peach-network microservice
     pub fn peach_network(&mut self, mut result: ProbeResult) -> ProbeResult {
-
         // probe endpoints which should successfully return if online
         self.probe_peach_endpoint(network_client::activate_ap(), "activate_ap", &mut result);
         self.probe_peach_endpoint(
@@ -323,7 +321,6 @@ impl PeachProbe {
 
     /// probes all endpoints on the peach-oled microservice
     pub fn peach_oled(&mut self, mut result: ProbeResult) -> ProbeResult {
-
         // probe endpoints
         self.probe_peach_endpoint(oled_client::ping(), "ping", &mut result);
 


### PR DESCRIPTION
This PR includes the following:
- updates the README to include usage and installation information 
- adds configuration for packaging peach-probe as a deb (I tested this on the pi and its working, after installing with dpkg you can run peach-probe by simply typing `peach-probe`)
- bumps the version number to 0.1.1

I probably should have separated the README and cargo deb stuff into two PRs but I did it together. 