### PR TITLE
Move switch modes to bottom so that all peach-probe tests pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "peach-probe"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "const_format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peach-probe"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
 description = "Diagnostic tool for probing PeachCloud microservices to evaluate their state and ensure correct API responses"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-probe
 
-![Generic badge](https://img.shields.io/badge/version-0.1.1-<COLOR>.svg)
+![Generic badge](https://img.shields.io/badge/version-0.1.2-<COLOR>.svg)
 
 Probe PeachCloud microservices to evaluate their state and ensure correct API responses.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,7 @@ arg_enum! {
         Peach_Stats,
         Peach_Menu,
         Peach_Web,
-        Peach_Buttons,
-        Peach_Monitor
+        Peach_Buttons
     }
 }
 
@@ -47,7 +46,6 @@ impl Microservice {
             Microservice::Peach_Stats => "peach-stats",
             Microservice::Peach_Menu => "peach-menu",
             Microservice::Peach_Web => "peach-web",
-            Microservice::Peach_Monitor => "peach-monitor",
             Microservice::Peach_Buttons => "peach-buttons",
         };
         s.to_string()
@@ -74,7 +72,6 @@ fn main() {
             Microservice::Peach_Network,
             Microservice::Peach_Oled,
             Microservice::Peach_Stats,
-            Microservice::Peach_Monitor,
             Microservice::Peach_Web,
             Microservice::Peach_Buttons,
             Microservice::Peach_Menu,

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -269,12 +269,6 @@ impl PeachProbe {
     /// probes all endpoints on peach-network microservice
     pub fn peach_network(&mut self, mut result: ProbeResult) -> ProbeResult {
         // probe endpoints which should successfully return if online
-        self.probe_peach_endpoint(network_client::activate_ap(), "activate_ap", &mut result);
-        self.probe_peach_endpoint(
-            network_client::activate_client(),
-            "activate_client",
-            &mut result,
-        );
         self.probe_peach_endpoint(
             network_client::add("peach-probe-test-ssid", "peach-probe-test-pass"),
             "add",
@@ -312,6 +306,14 @@ impl PeachProbe {
             network_client::connect("peach-probe-test-ssid", "wlan0"),
             "connect",
             -32027,
+            &mut result,
+        );
+
+        // probe switching between ap and client mode
+        self.probe_peach_endpoint(network_client::activate_ap(), "activate_ap", &mut result);
+        self.probe_peach_endpoint(
+            network_client::activate_client(),
+            "activate_client",
             &mut result,
         );
 


### PR DESCRIPTION
Included in this PR:
- remove peach-monitor from peach-probe (as it was offline)
- move activate_ap and activate_client tests to the bottom of the probe 

For some reason when they were run first in the probe, it would cause the later probes to fail... maybe something about timing... of course it could be valuable to look deeper into this, but I would like to merge this for now, as with this PR, and your latest changes to peach-network, now for the first time peach-probe passes all tests. 

There are more things that could be added to peach-probe to be a more robust better test of peach-network, but atleast having all the current tests passing, we can see if we break something and this can be a stable checkpoint. 